### PR TITLE
Add variableRegexp property

### DIFF
--- a/formulaParser.js
+++ b/formulaParser.js
@@ -50,7 +50,7 @@ function matchOperator(str, operatorList) {
  * @returns {?Object}
  */
 function _parseVariable(self, str) {
-  var variable = (str.match(/^\w+/) || [])[0];
+  var variable = (str.match(self.variableRegexp) || [])[0];
   if (!variable) {
     return null;
   }
@@ -189,10 +189,11 @@ function _parseFormula(self, currentString, currentPrecedence, currentJSON) {
  * @param {Object[]} unaries     - an array of unary operator definitions
  * @param {Object[]} binaries    - an array of binary operator definitions
  */
-function FormulaParser(variableKey, unaries, binaries) {
-  this.variableKey = variableKey || 'var';
-  this.unaries     = unaries     || [];
-  this.binaries    = binaries    || [];
+function FormulaParser(variableKey, unaries, binaries, variableRegexp) {
+  this.variableKey    = variableKey || 'var';
+  this.unaries        = unaries     || [];
+  this.binaries       = binaries    || [];
+  this.variableRegexp = variableRegexp || /^\w+/;
 }
 
 /**


### PR DESCRIPTION
I'm using this to parse formulas where the propositional variables are sentences about Tarski's World -- like Tet(a), Between(a, b, c), etc. --, like this:

```
// variableKey, unaries and binaries definitions here

var variableRegexp = /^[A-Z][^\)]*\)/;
var TarskiPropositionalFormulaParser = new FormulaParser(variableKey, unaries, binaries, variableRegexp);
```

Other people might need similar functionality, so I created this PR.

The earlier way of calling the constructor (without the variableRegexp argument) still works, and sets the variableRegexp property such that the class behaves identically to the earlier version.
