### PR TITLE
Handle the case when one operator symbol is a prefix of another one

### DIFF
--- a/formulaParser.js
+++ b/formulaParser.js
@@ -26,7 +26,7 @@ function sliceSymbol(str, symbol) {
 
 /**
  * Attempts to match a given list of operators against the head of a given string.
- * Returns the first match if successful, otherwise null.
+ * Returns the match having the longest symbol if successful, otherwise null.
  *
  * @private
  * @param {string}   str          - a string to match against
@@ -34,9 +34,10 @@ function sliceSymbol(str, symbol) {
  * @returns {?Object}
  */
 function matchOperator(str, operatorList) {
-  return operatorList.reduce(function (match, operator) {
-    return match ? match :
-      str.indexOf(operator.symbol) === 0 ? operator : null;
+  return operatorList.reduce(function (longestMatch, operator) {
+    return str.indexOf(operator.symbol) === 0 &&
+      (!longestMatch || operator.symbol.length > longestMatch.symbol.length) ?
+      operator : longestMatch;
   }, null);
 }
 


### PR DESCRIPTION
I ran into this because for Tarski's World I need 'Small' and 'Smaller', and 'Large' and 'Larger' operators. The problem occurs when an operator symbol is a prefix of another one, and the shorter one is listed first. (Thus, a workaround is always listing operators in prefix-nonincreasing order :) But instead of using this workaround, I rather fixed this, so that others don't have to deal with this in the future.)
