### PR TITLE
Allow non-alphanumeric characters in variables

### DIFF
--- a/formulaParser.js
+++ b/formulaParser.js
@@ -50,7 +50,7 @@ function matchOperator(str, operatorList) {
  * @returns {?Object}
  */
 function _parseVariable(self, str) {
-  var variable = (str.match(/^[^\s\(\)]+/) || [])[0];
+  var variable = (str.match(/^[^\s\(\),]+/) || [])[0];
   if (!variable) {
     return null;
   }

--- a/formulaParser.js
+++ b/formulaParser.js
@@ -50,7 +50,19 @@ function matchOperator(str, operatorList) {
  * @returns {?Object}
  */
 function _parseVariable(self, str) {
-  var variable = (str.match(/^[^\s\(\),]+/) || [])[0];
+  var variable = '';
+  var strClone = str;
+  while (strClone) {
+    if (
+      strClone[0].match(/[\s\(\)]/) ||
+      matchOperator(strClone, self.unaries) ||
+      matchOperator(strClone, self.binaries)
+    ) {
+      break;
+    }
+    variable += strClone[0];
+    strClone = strClone.slice(1);
+  }
   if (!variable) {
     return null;
   }

--- a/formulaParser.js
+++ b/formulaParser.js
@@ -50,7 +50,7 @@ function matchOperator(str, operatorList) {
  * @returns {?Object}
  */
 function _parseVariable(self, str) {
-  var variable = (str.match(/^\w+/) || [])[0];
+  var variable = (str.match(/^[^\s\(\)]+/) || [])[0];
   if (!variable) {
     return null;
   }


### PR DESCRIPTION
I needed `*` as a variable, and as far as I understand, only whitespace and parentheses are special to the parsing, so I modified variable parsing to allow any character besides these.
